### PR TITLE
fix: max length

### DIFF
--- a/.changeset/full-wombats-relax.md
+++ b/.changeset/full-wombats-relax.md
@@ -1,0 +1,5 @@
+---
+"scrubjay": patch
+---
+
+fix max length for rss description

--- a/apps/scrubjay/src/features/dispatcher/dispatchers/rss-dispatcher.service.ts
+++ b/apps/scrubjay/src/features/dispatcher/dispatchers/rss-dispatcher.service.ts
@@ -37,13 +37,19 @@ export class RssDispatcherService implements Dispatcher<DispatchableRssItem[]> {
 
     if (rssItem.description) {
       let description = rssItem.description;
-      if (description.length > 2000) {
-        description = `${description.substring(0, 2000)}...`;
-        if (rssItem.link) {
-          description += `\n\n[Read more](${rssItem.link})`;
-        }
+      const maxLength = 1024; // Discord embed field value max length
+
+      if (description.length > maxLength) {
+        // Reserve space for "Read more" link if available
+        const readMoreText = rssItem.link
+          ? `\n\n[Read more](${rssItem.link})`
+          : "";
+        const reservedLength = readMoreText.length;
+        const truncateLength = maxLength - reservedLength - 3; // -3 for "..."
+
+        description = `${description.substring(0, truncateLength)}...${readMoreText}`;
       } else {
-        description = description.substring(0, 2000);
+        description = description.substring(0, maxLength);
       }
       embed.addFields({ name: "Description", value: description });
     }


### PR DESCRIPTION
Discord, apparently, restricts the length of fields to 1024 chars. This PR adjusts the length of the generated string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust RSS embed description truncation to 1024 chars, reserving space for ellipsis and optional "Read more" link.
> 
> - **RSS Dispatcher (`apps/scrubjay/src/features/dispatcher/dispatchers/rss-dispatcher.service.ts`)**:
>   - Limit `Description` embed field to `1024` chars (was `2000`).
>   - When over limit, truncate accounting for `...` and optional `"Read more"` link, otherwise cap to `maxLength`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4dab3da99d0b81733b1d8cab53cf65bbd2f5bc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->