### PR TITLE
chore: update release workflow and add status checks workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@${{ github.repository_owner }}"
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   status-checks:
     name: Status Checks

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -1,0 +1,29 @@
+name: Status Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  status-checks:
+    name: Status Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run status checks
+        run: pnpm run format-and-lint

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   status-checks:
     name: Status Checks

--- a/apps/mock-api/src/data/hotspots.ts
+++ b/apps/mock-api/src/data/hotspots.ts
@@ -69,4 +69,3 @@ export const hotspots: Record<string, Hotspot[]> = {
     },
   ],
 };
-

--- a/apps/mock-api/src/data/regions.ts
+++ b/apps/mock-api/src/data/regions.ts
@@ -65,4 +65,3 @@ export const regions = {
     timezone: "America/Los_Angeles",
   },
 };
-

--- a/apps/mock-api/src/data/species.ts
+++ b/apps/mock-api/src/data/species.ts
@@ -243,4 +243,3 @@ export const species = [
     speciesCode: "perfal",
   },
 ];
-

--- a/apps/mock-api/src/middleware/auth.ts
+++ b/apps/mock-api/src/middleware/auth.ts
@@ -23,4 +23,3 @@ export function authenticateApiKey(
 export function getApiKeys(): string[] {
   return Array.from(apiKeys);
 }
-

--- a/apps/mock-api/src/middleware/rate-limit.ts
+++ b/apps/mock-api/src/middleware/rate-limit.ts
@@ -24,4 +24,3 @@ export function rateLimit(
   rateLimits[apiKey].count++;
   next();
 }
-

--- a/apps/mock-api/src/routes/ebird.routes.ts
+++ b/apps/mock-api/src/routes/ebird.routes.ts
@@ -443,4 +443,3 @@ export function createEbirdRoutes() {
 
   return router;
 }
-

--- a/apps/scrubjay-discord/src/discord/reaction-router/reaction-router.service.ts
+++ b/apps/scrubjay-discord/src/discord/reaction-router/reaction-router.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { Injectable, OnModuleInit } from "@nestjs/common";
 import { ReactionExplorer } from "./reaction-explorer.service";
 import type {
   ReactionHandler,

--- a/apps/scrubjay-discord/src/drizzle/meta/0001_snapshot.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/0001_snapshot.json
@@ -1,756 +1,734 @@
 {
-  "id": "c0d0dc8e-b5f7-411e-aa7c-232cbe2ec39c",
-  "prevId": "79d9052a-8da0-4623-a61c-7a067c172d2b",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.channel_ebird_subscriptions": {
-      "name": "channel_ebird_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "state_county_idx": {
-          "name": "state_county_idx",
-          "columns": [
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "active_state_county_idx": {
-          "name": "active_state_county_idx",
-          "columns": [
-            {
-              "expression": "active",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
-          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk",
-          "columns": [
-            "channel_id",
-            "state_code",
-            "county_code"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.channel_rss_subscriptions": {
-      "name": "channel_rss_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "channel_rss_subscriptions_id_rss_sources_id_fk": {
-          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
-          "tableFrom": "channel_rss_subscriptions",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.county_timezones": {
-      "name": "county_timezones",
-      "schema": "",
-      "columns": {
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "timezone": {
-          "name": "timezone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'America/Los_Angeles'"
-        }
-      },
-      "indexes": {
-        "county_code_idx": {
-          "name": "county_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.deliveries": {
-      "name": "deliveries",
-      "schema": "",
-      "columns": {
-        "alert_id": {
-          "name": "alert_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "alert_kind": {
-          "name": "alert_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sent_at": {
-          "name": "sent_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "deliveries_unique_idx": {
-          "name": "deliveries_unique_idx",
-          "columns": [
-            {
-              "expression": "alert_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "alert_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "deliveries_channel_idx": {
-          "name": "deliveries_channel_idx",
-          "columns": [
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.filtered_species": {
-      "name": "filtered_species",
-      "schema": "",
-      "columns": {
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "common_name_channel_id_idx": {
-          "name": "common_name_channel_id_idx",
-          "columns": [
-            {
-              "expression": "common_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "filtered_species_common_name_channel_id_pk": {
-          "name": "filtered_species_common_name_channel_id_pk",
-          "columns": [
-            "common_name",
-            "channel_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.locations": {
-      "name": "locations",
-      "schema": "",
-      "columns": {
-        "county": {
-          "name": "county",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "is_private": {
-          "name": "is_private",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "lat": {
-          "name": "lat",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "county_state_code_idx": {
-          "name": "county_state_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.observations": {
-      "name": "observations",
-      "schema": "",
-      "columns": {
-        "audio_count": {
-          "name": "audio_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "has_comments": {
-          "name": "has_comments",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "how_many": {
-          "name": "how_many",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "location_id": {
-          "name": "location_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_date": {
-          "name": "observation_date",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_reviewed": {
-          "name": "observation_reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_valid": {
-          "name": "observation_valid",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "photo_count": {
-          "name": "photo_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "presence_noted": {
-          "name": "presence_noted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scientific_name": {
-          "name": "scientific_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "species_code": {
-          "name": "species_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sub_id": {
-          "name": "sub_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "video_count": {
-          "name": "video_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        }
-      },
-      "indexes": {
-        "obs_created_at_idx": {
-          "name": "obs_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_location_date_idx": {
-          "name": "obs_location_date_idx",
-          "columns": [
-            {
-              "expression": "location_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_review_valid_date_idx": {
-          "name": "obs_review_valid_date_idx",
-          "columns": [
-            {
-              "expression": "observation_reviewed",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_valid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "observations_location_id_locations_id_fk": {
-          "name": "observations_location_id_locations_id_fk",
-          "tableFrom": "observations",
-          "tableTo": "locations",
-          "columnsFrom": [
-            "location_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {
-        "observations_species_code_sub_id_pk": {
-          "name": "observations_species_code_sub_id_pk",
-          "columns": [
-            "species_code",
-            "sub_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_items": {
-      "name": "rss_items",
-      "schema": "",
-      "columns": {
-        "content_html": {
-          "name": "content_html",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "link": {
-          "name": "link",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "published_at": {
-          "name": "published_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "rss_items_id_rss_sources_id_fk": {
-          "name": "rss_items_id_rss_sources_id_fk",
-          "tableFrom": "rss_items",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_sources": {
-      "name": "rss_sources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "url": {
-          "name": "url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},
     "tables": {}
-  }
+  },
+  "dialect": "postgresql",
+  "enums": {},
+  "id": "c0d0dc8e-b5f7-411e-aa7c-232cbe2ec39c",
+  "policies": {},
+  "prevId": "79d9052a-8da0-4623-a61c-7a067c172d2b",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.channel_ebird_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
+          "columns": ["channel_id", "state_code", "county_code"],
+          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "active_state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "active",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "active_state_county_idx",
+          "with": {}
+        },
+        "state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "state_county_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "channel_ebird_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.channel_rss_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channel_rss_subscriptions_id_rss_sources_id_fk": {
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "channel_rss_subscriptions",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channel_rss_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.county_timezones": {
+      "checkConstraints": {},
+      "columns": {
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "timezone": {
+          "default": "'America/Los_Angeles'",
+          "name": "timezone",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "county_timezones",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.deliveries": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "alert_kind": {
+          "name": "alert_kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "serial"
+        },
+        "sent_at": {
+          "default": "now()",
+          "name": "sent_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "deliveries_channel_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "deliveries_channel_idx",
+          "with": {}
+        },
+        "deliveries_unique_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "alert_kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "alert_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "deliveries_unique_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "deliveries",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.filtered_species": {
+      "checkConstraints": {},
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filtered_species_common_name_channel_id_pk": {
+          "columns": ["common_name", "channel_id"],
+          "name": "filtered_species_common_name_channel_id_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "common_name_channel_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "common_name",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "common_name_channel_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "filtered_species",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.locations": {
+      "checkConstraints": {},
+      "columns": {
+        "county": {
+          "name": "county",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "is_private": {
+          "name": "is_private",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "lat": {
+          "name": "lat",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "lng": {
+          "name": "lng",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state": {
+          "name": "state",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_state_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_state_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "locations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.observations": {
+      "checkConstraints": {},
+      "columns": {
+        "audio_count": {
+          "default": 0,
+          "name": "audio_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "has_comments": {
+          "name": "has_comments",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "how_many": {
+          "name": "how_many",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "location_id": {
+          "name": "location_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "observation_date": {
+          "name": "observation_date",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "observation_reviewed": {
+          "name": "observation_reviewed",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "observation_valid": {
+          "name": "observation_valid",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "photo_count": {
+          "default": 0,
+          "name": "photo_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "presence_noted": {
+          "name": "presence_noted",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "species_code": {
+          "name": "species_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "sub_id": {
+          "name": "sub_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "video_count": {
+          "default": 0,
+          "name": "video_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observations_species_code_sub_id_pk": {
+          "columns": ["species_code", "sub_id"],
+          "name": "observations_species_code_sub_id_pk"
+        }
+      },
+      "foreignKeys": {
+        "observations_location_id_locations_id_fk": {
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "name": "observations_location_id_locations_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "observations",
+          "tableTo": "locations"
+        }
+      },
+      "indexes": {
+        "obs_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_created_at_idx",
+          "with": {}
+        },
+        "obs_location_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "location_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_location_date_idx",
+          "with": {}
+        },
+        "obs_review_valid_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "observation_reviewed",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_valid",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_review_valid_date_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "observations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_items": {
+      "checkConstraints": {},
+      "columns": {
+        "content_html": {
+          "name": "content_html",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "link": {
+          "name": "link",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "published_at": {
+          "name": "published_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "title": {
+          "name": "title",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "rss_items_id_rss_sources_id_fk": {
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "name": "rss_items_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "rss_items",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_items",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_sources": {
+      "checkConstraints": {},
+      "columns": {
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_sources",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
 }

--- a/apps/scrubjay-discord/src/drizzle/meta/0002_snapshot.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/0002_snapshot.json
@@ -1,762 +1,740 @@
 {
-  "id": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
-  "prevId": "c0d0dc8e-b5f7-411e-aa7c-232cbe2ec39c",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.channel_ebird_subscriptions": {
-      "name": "channel_ebird_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "state_county_idx": {
-          "name": "state_county_idx",
-          "columns": [
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "active_state_county_idx": {
-          "name": "active_state_county_idx",
-          "columns": [
-            {
-              "expression": "active",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
-          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk",
-          "columns": [
-            "channel_id",
-            "state_code",
-            "county_code"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.channel_rss_subscriptions": {
-      "name": "channel_rss_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "channel_rss_subscriptions_id_rss_sources_id_fk": {
-          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
-          "tableFrom": "channel_rss_subscriptions",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.county_timezones": {
-      "name": "county_timezones",
-      "schema": "",
-      "columns": {
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "timezone": {
-          "name": "timezone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'America/Los_Angeles'"
-        }
-      },
-      "indexes": {
-        "county_code_idx": {
-          "name": "county_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.deliveries": {
-      "name": "deliveries",
-      "schema": "",
-      "columns": {
-        "alert_id": {
-          "name": "alert_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "alert_kind": {
-          "name": "alert_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sent_at": {
-          "name": "sent_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "deliveries_unique_idx": {
-          "name": "deliveries_unique_idx",
-          "columns": [
-            {
-              "expression": "alert_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "alert_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "deliveries_channel_idx": {
-          "name": "deliveries_channel_idx",
-          "columns": [
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.filtered_species": {
-      "name": "filtered_species",
-      "schema": "",
-      "columns": {
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "common_name_channel_id_idx": {
-          "name": "common_name_channel_id_idx",
-          "columns": [
-            {
-              "expression": "common_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "filtered_species_common_name_channel_id_pk": {
-          "name": "filtered_species_common_name_channel_id_pk",
-          "columns": [
-            "common_name",
-            "channel_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.locations": {
-      "name": "locations",
-      "schema": "",
-      "columns": {
-        "county": {
-          "name": "county",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "is_private": {
-          "name": "is_private",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "lat": {
-          "name": "lat",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "county_state_code_idx": {
-          "name": "county_state_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.observations": {
-      "name": "observations",
-      "schema": "",
-      "columns": {
-        "audio_count": {
-          "name": "audio_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "has_comments": {
-          "name": "has_comments",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "how_many": {
-          "name": "how_many",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "location_id": {
-          "name": "location_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_date": {
-          "name": "observation_date",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_reviewed": {
-          "name": "observation_reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_valid": {
-          "name": "observation_valid",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "photo_count": {
-          "name": "photo_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "presence_noted": {
-          "name": "presence_noted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scientific_name": {
-          "name": "scientific_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "species_code": {
-          "name": "species_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sub_id": {
-          "name": "sub_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "video_count": {
-          "name": "video_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        }
-      },
-      "indexes": {
-        "obs_created_at_idx": {
-          "name": "obs_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_location_date_idx": {
-          "name": "obs_location_date_idx",
-          "columns": [
-            {
-              "expression": "location_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_review_valid_date_idx": {
-          "name": "obs_review_valid_date_idx",
-          "columns": [
-            {
-              "expression": "observation_reviewed",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_valid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "observations_location_id_locations_id_fk": {
-          "name": "observations_location_id_locations_id_fk",
-          "tableFrom": "observations",
-          "tableTo": "locations",
-          "columnsFrom": [
-            "location_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {
-        "observations_species_code_sub_id_pk": {
-          "name": "observations_species_code_sub_id_pk",
-          "columns": [
-            "species_code",
-            "sub_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_items": {
-      "name": "rss_items",
-      "schema": "",
-      "columns": {
-        "content_html": {
-          "name": "content_html",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "link": {
-          "name": "link",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "published_at": {
-          "name": "published_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "source_id": {
-          "name": "source_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "rss_items_source_id_rss_sources_id_fk": {
-          "name": "rss_items_source_id_rss_sources_id_fk",
-          "tableFrom": "rss_items",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "source_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_sources": {
-      "name": "rss_sources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "url": {
-          "name": "url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},
     "tables": {}
-  }
+  },
+  "dialect": "postgresql",
+  "enums": {},
+  "id": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
+  "policies": {},
+  "prevId": "c0d0dc8e-b5f7-411e-aa7c-232cbe2ec39c",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.channel_ebird_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
+          "columns": ["channel_id", "state_code", "county_code"],
+          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "active_state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "active",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "active_state_county_idx",
+          "with": {}
+        },
+        "state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "state_county_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "channel_ebird_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.channel_rss_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channel_rss_subscriptions_id_rss_sources_id_fk": {
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "channel_rss_subscriptions",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channel_rss_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.county_timezones": {
+      "checkConstraints": {},
+      "columns": {
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "timezone": {
+          "default": "'America/Los_Angeles'",
+          "name": "timezone",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "county_timezones",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.deliveries": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "alert_kind": {
+          "name": "alert_kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "serial"
+        },
+        "sent_at": {
+          "default": "now()",
+          "name": "sent_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "deliveries_channel_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "deliveries_channel_idx",
+          "with": {}
+        },
+        "deliveries_unique_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "alert_kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "alert_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "deliveries_unique_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "deliveries",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.filtered_species": {
+      "checkConstraints": {},
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filtered_species_common_name_channel_id_pk": {
+          "columns": ["common_name", "channel_id"],
+          "name": "filtered_species_common_name_channel_id_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "common_name_channel_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "common_name",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "common_name_channel_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "filtered_species",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.locations": {
+      "checkConstraints": {},
+      "columns": {
+        "county": {
+          "name": "county",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "is_private": {
+          "name": "is_private",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "lat": {
+          "name": "lat",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "lng": {
+          "name": "lng",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state": {
+          "name": "state",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_state_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_state_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "locations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.observations": {
+      "checkConstraints": {},
+      "columns": {
+        "audio_count": {
+          "default": 0,
+          "name": "audio_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "has_comments": {
+          "name": "has_comments",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "how_many": {
+          "name": "how_many",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "location_id": {
+          "name": "location_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "observation_date": {
+          "name": "observation_date",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "observation_reviewed": {
+          "name": "observation_reviewed",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "observation_valid": {
+          "name": "observation_valid",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "photo_count": {
+          "default": 0,
+          "name": "photo_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "presence_noted": {
+          "name": "presence_noted",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "species_code": {
+          "name": "species_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "sub_id": {
+          "name": "sub_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "video_count": {
+          "default": 0,
+          "name": "video_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observations_species_code_sub_id_pk": {
+          "columns": ["species_code", "sub_id"],
+          "name": "observations_species_code_sub_id_pk"
+        }
+      },
+      "foreignKeys": {
+        "observations_location_id_locations_id_fk": {
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "name": "observations_location_id_locations_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "observations",
+          "tableTo": "locations"
+        }
+      },
+      "indexes": {
+        "obs_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_created_at_idx",
+          "with": {}
+        },
+        "obs_location_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "location_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_location_date_idx",
+          "with": {}
+        },
+        "obs_review_valid_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "observation_reviewed",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_valid",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_review_valid_date_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "observations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_items": {
+      "checkConstraints": {},
+      "columns": {
+        "content_html": {
+          "name": "content_html",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "link": {
+          "name": "link",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "published_at": {
+          "name": "published_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "source_id": {
+          "name": "source_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "title": {
+          "name": "title",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "rss_items_source_id_rss_sources_id_fk": {
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "name": "rss_items_source_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "rss_items",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_items",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_sources": {
+      "checkConstraints": {},
+      "columns": {
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_sources",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
 }

--- a/apps/scrubjay-discord/src/drizzle/meta/_journal.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/_journal.json
@@ -9,18 +9,18 @@
       "when": 1763235970223
     },
     {
+      "breakpoints": true,
       "idx": 1,
-      "version": "7",
-      "when": 1763786799547,
       "tag": "0001_watery_hairball",
-      "breakpoints": true
+      "version": "7",
+      "when": 1763786799547
     },
     {
+      "breakpoints": true,
       "idx": 2,
-      "version": "7",
-      "when": 1763787622015,
       "tag": "0002_silky_psylocke",
-      "breakpoints": true
+      "version": "7",
+      "when": 1763787622015
     }
   ],
   "version": "7"

--- a/apps/scrubjay-discord/src/features/dispatcher/dispatcher.module.ts
+++ b/apps/scrubjay-discord/src/features/dispatcher/dispatcher.module.ts
@@ -2,9 +2,9 @@ import { Module } from "@nestjs/common";
 import { DrizzleModule } from "@/core/drizzle/drizzle.module";
 import { DiscordModule } from "@/discord/discord.module";
 import { DeliveriesModule } from "@/features/deliveries/deliveries.module";
-import { EBirdDispatcherService } from "./dispatchers/ebird-dispatcher.service";
 import { DispatcherRepository } from "./dispatcher.repository";
 import { DispatcherService } from "./dispatcher.service";
+import { EBirdDispatcherService } from "./dispatchers/ebird-dispatcher.service";
 import { RssDispatcherService } from "./dispatchers/rss-dispatcher.service";
 
 @Module({

--- a/apps/scrubjay-discord/src/features/dispatcher/dispatcher.service.ts
+++ b/apps/scrubjay-discord/src/features/dispatcher/dispatcher.service.ts
@@ -5,6 +5,7 @@ import { RssDispatcherService } from "./dispatchers/rss-dispatcher.service";
 
 @Injectable()
 export class DispatcherService {
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: used via bracket notation in getDispatcher
   private readonly dispatchers: Readonly<DispatcherMap>;
 
   constructor(

--- a/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.fetcher.spec.ts
+++ b/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.fetcher.spec.ts
@@ -14,7 +14,7 @@ describe("EBirdFetcher", () => {
       providers: [
         {
           provide: EBirdFetcher,
-          useFactory: () => new EBirdFetcher(configServiceMock as any),
+          useFactory: () => new EBirdFetcher(configServiceMock),
         },
       ],
     }).compile();

--- a/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.service.spec.ts
+++ b/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.service.spec.ts
@@ -1,8 +1,11 @@
 import { Test, type TestingModule } from "@nestjs/testing";
 import { EBirdFetcher } from "../ebird.fetcher";
 import { EBirdRepository } from "../ebird.repository";
+import type {
+  EBirdObservation,
+  TransformedEBirdObservation,
+} from "../ebird.schema";
 import { EBirdService } from "../ebird.service";
-import type { EBirdObservation, TransformedEBirdObservation } from "../ebird.schema";
 import { EBirdTransformer } from "../ebird.transformer";
 
 describe("EBirdService", () => {
@@ -36,9 +39,9 @@ describe("EBirdService", () => {
     lastName: "",
     lat: 47.6062,
     lng: -122.3321,
+    locationPrivate: false,
     locId: "loc-1",
     locName: "Lake Union",
-    locationPrivate: false,
     obsDt: "2024-01-01T10:00:00Z",
     obsId: "obs-1",
     obsReviewed: true,
@@ -121,9 +124,9 @@ describe("EBirdService", () => {
       countryName: "United States",
       lat: 47.6062,
       lng: -122.3321,
+      locationPrivate: false,
       locId: "loc-1",
       locName: "Lake Union",
-      locationPrivate: false,
       subnational1Code: "US-WA",
       subnational1Name: "Washington",
       subnational2Code: "US-WA-033",

--- a/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.transformer.spec.ts
+++ b/apps/scrubjay-discord/src/features/ebird/__tests__/ebird.transformer.spec.ts
@@ -1,5 +1,5 @@
-import { EBirdTransformer } from "../ebird.transformer";
 import type { EBirdObservation } from "../ebird.schema";
+import { EBirdTransformer } from "../ebird.transformer";
 
 describe("EBirdTransformer", () => {
   const transformer = new EBirdTransformer();
@@ -17,9 +17,9 @@ describe("EBirdTransformer", () => {
     lastName: "",
     lat: 47.6062,
     lng: -122.3321,
+    locationPrivate: false,
     locId: "loc-1",
     locName: "Lake Union",
-    locationPrivate: false,
     obsDt: "2024-01-01T10:00:00Z",
     obsId: "obs-1",
     obsReviewed: true,
@@ -48,8 +48,8 @@ describe("EBirdTransformer", () => {
         ...baseObservation,
         evidence: "V",
         obsId: "obs-3",
-        subId: "sub-2",
         speciesCode: "mallar",
+        subId: "sub-2",
       },
     ]);
 
@@ -75,9 +75,9 @@ describe("EBirdTransformer", () => {
       countryName: "United States",
       lat: 47.6062,
       lng: -122.3321,
+      locationPrivate: false,
       locId: "loc-1",
       locName: "Lake Union",
-      locationPrivate: false,
       subnational1Code: "US-WA",
       subnational1Name: "Washington",
       subnational2Code: "US-WA-033",

--- a/apps/scrubjay-discord/src/features/filters/__tests__/filters-add.handler.spec.ts
+++ b/apps/scrubjay-discord/src/features/filters/__tests__/filters-add.handler.spec.ts
@@ -1,7 +1,7 @@
 import { Test, type TestingModule } from "@nestjs/testing";
 import type { MessageReaction } from "discord.js";
-import { FiltersAddHandler } from "../handlers/filters-add.handler";
 import { FiltersService } from "../filters.service";
+import { FiltersAddHandler } from "../handlers/filters-add.handler";
 
 describe("FiltersAddHandler", () => {
   let handler: FiltersAddHandler;


### PR DESCRIPTION
- Removed unnecessary registry configuration from release.yml.
- Introduced a new status-checks.yml workflow to run format and lint checks on pull requests to the main branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the release workflow by removing npm registry config and adds a PR status-checks workflow for format/lint, alongside minor code/test cleanups and Drizzle meta updates.
> 
> - **CI**:
>   - **Release**: Remove npm registry configuration from `actions/setup-node` in `.github/workflows/release.yml`.
>   - **Status Checks**: Add `.github/workflows/status-checks.yml` to install deps and run `pnpm run format-and-lint` on PRs to `main`.
> - **Code Quality**:
>   - Remove unused `Logger` import in `discord/reaction-router.service.ts` and reorder/import cleanups across tests and modules; add lint directive in `dispatcher.service.ts`.
> - **Drizzle Meta**:
>   - Update snapshot and journal metadata files in `apps/scrubjay-discord/src/drizzle/meta/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56f93f107fa07f78724d04308122e18077d57a7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->