### PR TITLE
fix: missing primary key for channel rss subscriptions

### DIFF
--- a/.changeset/tasty-meals-share.md
+++ b/.changeset/tasty-meals-share.md
@@ -1,0 +1,5 @@
+---
+"scrubjay-discord": patch
+---
+
+bugfix: create composite primary key on channelId and sourceId for channelRssSubscriptions table

--- a/apps/scrubjay-discord/src/core/drizzle/drizzle.schema.ts
+++ b/apps/scrubjay-discord/src/core/drizzle/drizzle.schema.ts
@@ -136,14 +136,18 @@ export const rssSources = pgTable("rss_sources", {
   url: text("url").notNull(),
 });
 
-export const channelRssSubscriptions = pgTable("channel_rss_subscriptions", {
-  active: boolean("active").notNull().default(true),
-  channelId: text("channel_id").notNull(),
-  sourceId: text("id").references(() => rssSources.id, {
-    onDelete: "cascade",
-    onUpdate: "cascade",
-  }),
-});
+export const channelRssSubscriptions = pgTable(
+  "channel_rss_subscriptions",
+  {
+    active: boolean("active").notNull().default(true),
+    channelId: text("channel_id").notNull(),
+    sourceId: text("id").references(() => rssSources.id, {
+      onDelete: "cascade",
+      onUpdate: "cascade",
+    }),
+  },
+  (t) => [primaryKey({ columns: [t.channelId, t.sourceId] })],
+);
 
 export const deliveries = pgTable(
   "deliveries",

--- a/apps/scrubjay-discord/src/core/drizzle/drizzle.schema.ts
+++ b/apps/scrubjay-discord/src/core/drizzle/drizzle.schema.ts
@@ -141,10 +141,12 @@ export const channelRssSubscriptions = pgTable(
   {
     active: boolean("active").notNull().default(true),
     channelId: text("channel_id").notNull(),
-    sourceId: text("id").references(() => rssSources.id, {
-      onDelete: "cascade",
-      onUpdate: "cascade",
-    }),
+    sourceId: text("id")
+      .references(() => rssSources.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      })
+      .notNull(),
   },
   (t) => [primaryKey({ columns: [t.channelId, t.sourceId] })],
 );

--- a/apps/scrubjay-discord/src/drizzle/0003_brainy_zzzax.sql
+++ b/apps/scrubjay-discord/src/drizzle/0003_brainy_zzzax.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "channel_rss_subscriptions" ADD CONSTRAINT "channel_rss_subscriptions_channel_id_id_pk" PRIMARY KEY("channel_id","id");

--- a/apps/scrubjay-discord/src/drizzle/0003_freezing_princess_powerful.sql
+++ b/apps/scrubjay-discord/src/drizzle/0003_freezing_princess_powerful.sql
@@ -1,1 +1,2 @@
+ALTER TABLE "channel_rss_subscriptions" ALTER COLUMN "id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "channel_rss_subscriptions" ADD CONSTRAINT "channel_rss_subscriptions_channel_id_id_pk" PRIMARY KEY("channel_id","id");

--- a/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
@@ -6,7 +6,7 @@
   },
   "dialect": "postgresql",
   "enums": {},
-  "id": "f8b3b934-4165-4200-be4c-3fe339cd6a6a",
+  "id": "4b4a9bb3-9220-4208-9844-6bde772bed60",
   "policies": {},
   "prevId": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
   "roles": {},
@@ -130,7 +130,7 @@
         },
         "id": {
           "name": "id",
-          "notNull": false,
+          "notNull": true,
           "primaryKey": false,
           "type": "text"
         }

--- a/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
@@ -1,770 +1,745 @@
 {
-  "id": "f8b3b934-4165-4200-be4c-3fe339cd6a6a",
-  "prevId": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.channel_ebird_subscriptions": {
-      "name": "channel_ebird_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "state_county_idx": {
-          "name": "state_county_idx",
-          "columns": [
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "active_state_county_idx": {
-          "name": "active_state_county_idx",
-          "columns": [
-            {
-              "expression": "active",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
-          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk",
-          "columns": [
-            "channel_id",
-            "state_code",
-            "county_code"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.channel_rss_subscriptions": {
-      "name": "channel_rss_subscriptions",
-      "schema": "",
-      "columns": {
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "channel_rss_subscriptions_id_rss_sources_id_fk": {
-          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
-          "tableFrom": "channel_rss_subscriptions",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {
-        "channel_rss_subscriptions_channel_id_id_pk": {
-          "name": "channel_rss_subscriptions_channel_id_id_pk",
-          "columns": [
-            "channel_id",
-            "id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.county_timezones": {
-      "name": "county_timezones",
-      "schema": "",
-      "columns": {
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "timezone": {
-          "name": "timezone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'America/Los_Angeles'"
-        }
-      },
-      "indexes": {
-        "county_code_idx": {
-          "name": "county_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.deliveries": {
-      "name": "deliveries",
-      "schema": "",
-      "columns": {
-        "alert_id": {
-          "name": "alert_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "alert_kind": {
-          "name": "alert_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sent_at": {
-          "name": "sent_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "deliveries_unique_idx": {
-          "name": "deliveries_unique_idx",
-          "columns": [
-            {
-              "expression": "alert_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "alert_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "deliveries_channel_idx": {
-          "name": "deliveries_channel_idx",
-          "columns": [
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.filtered_species": {
-      "name": "filtered_species",
-      "schema": "",
-      "columns": {
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "common_name_channel_id_idx": {
-          "name": "common_name_channel_id_idx",
-          "columns": [
-            {
-              "expression": "common_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "channel_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "filtered_species_common_name_channel_id_pk": {
-          "name": "filtered_species_common_name_channel_id_pk",
-          "columns": [
-            "common_name",
-            "channel_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.locations": {
-      "name": "locations",
-      "schema": "",
-      "columns": {
-        "county": {
-          "name": "county",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county_code": {
-          "name": "county_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "is_private": {
-          "name": "is_private",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "lat": {
-          "name": "lat",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lng": {
-          "name": "lng",
-          "type": "real",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state_code": {
-          "name": "state_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "county_state_code_idx": {
-          "name": "county_state_code_idx",
-          "columns": [
-            {
-              "expression": "county_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "state_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.observations": {
-      "name": "observations",
-      "schema": "",
-      "columns": {
-        "audio_count": {
-          "name": "audio_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "common_name": {
-          "name": "common_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "has_comments": {
-          "name": "has_comments",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "how_many": {
-          "name": "how_many",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "location_id": {
-          "name": "location_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_date": {
-          "name": "observation_date",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_reviewed": {
-          "name": "observation_reviewed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "observation_valid": {
-          "name": "observation_valid",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "photo_count": {
-          "name": "photo_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "presence_noted": {
-          "name": "presence_noted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scientific_name": {
-          "name": "scientific_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "species_code": {
-          "name": "species_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sub_id": {
-          "name": "sub_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "video_count": {
-          "name": "video_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        }
-      },
-      "indexes": {
-        "obs_created_at_idx": {
-          "name": "obs_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_location_date_idx": {
-          "name": "obs_location_date_idx",
-          "columns": [
-            {
-              "expression": "location_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "obs_review_valid_date_idx": {
-          "name": "obs_review_valid_date_idx",
-          "columns": [
-            {
-              "expression": "observation_reviewed",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_valid",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "observation_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "observations_location_id_locations_id_fk": {
-          "name": "observations_location_id_locations_id_fk",
-          "tableFrom": "observations",
-          "tableTo": "locations",
-          "columnsFrom": [
-            "location_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {
-        "observations_species_code_sub_id_pk": {
-          "name": "observations_species_code_sub_id_pk",
-          "columns": [
-            "species_code",
-            "sub_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_items": {
-      "name": "rss_items",
-      "schema": "",
-      "columns": {
-        "content_html": {
-          "name": "content_html",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "last_updated": {
-          "name": "last_updated",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "CURRENT_TIMESTAMP"
-        },
-        "link": {
-          "name": "link",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "published_at": {
-          "name": "published_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "source_id": {
-          "name": "source_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "rss_items_source_id_rss_sources_id_fk": {
-          "name": "rss_items_source_id_rss_sources_id_fk",
-          "tableFrom": "rss_items",
-          "tableTo": "rss_sources",
-          "columnsFrom": [
-            "source_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rss_sources": {
-      "name": "rss_sources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "url": {
-          "name": "url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},
     "tables": {}
-  }
+  },
+  "dialect": "postgresql",
+  "enums": {},
+  "id": "f8b3b934-4165-4200-be4c-3fe339cd6a6a",
+  "policies": {},
+  "prevId": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.channel_ebird_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
+          "columns": ["channel_id", "state_code", "county_code"],
+          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "active_state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "active",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "active_state_county_idx",
+          "with": {}
+        },
+        "state_county_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "state_county_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "channel_ebird_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.channel_rss_subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_rss_subscriptions_channel_id_id_pk": {
+          "columns": ["channel_id", "id"],
+          "name": "channel_rss_subscriptions_channel_id_id_pk"
+        }
+      },
+      "foreignKeys": {
+        "channel_rss_subscriptions_id_rss_sources_id_fk": {
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "channel_rss_subscriptions",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channel_rss_subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.county_timezones": {
+      "checkConstraints": {},
+      "columns": {
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "timezone": {
+          "default": "'America/Los_Angeles'",
+          "name": "timezone",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "county_timezones",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.deliveries": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "alert_kind": {
+          "name": "alert_kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "serial"
+        },
+        "sent_at": {
+          "default": "now()",
+          "name": "sent_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "deliveries_channel_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "deliveries_channel_idx",
+          "with": {}
+        },
+        "deliveries_unique_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "alert_kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "alert_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "deliveries_unique_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "deliveries",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.filtered_species": {
+      "checkConstraints": {},
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {
+        "filtered_species_common_name_channel_id_pk": {
+          "columns": ["common_name", "channel_id"],
+          "name": "filtered_species_common_name_channel_id_pk"
+        }
+      },
+      "foreignKeys": {},
+      "indexes": {
+        "common_name_channel_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "common_name",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "channel_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "common_name_channel_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "filtered_species",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.locations": {
+      "checkConstraints": {},
+      "columns": {
+        "county": {
+          "name": "county",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "county_code": {
+          "name": "county_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "is_private": {
+          "name": "is_private",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "lat": {
+          "name": "lat",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "lng": {
+          "name": "lng",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "real"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state": {
+          "name": "state",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "state_code": {
+          "name": "state_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "county_state_code_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "county_code",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "state_code",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "county_state_code_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "locations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.observations": {
+      "checkConstraints": {},
+      "columns": {
+        "audio_count": {
+          "default": 0,
+          "name": "audio_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "common_name": {
+          "name": "common_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "has_comments": {
+          "name": "has_comments",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "how_many": {
+          "name": "how_many",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "location_id": {
+          "name": "location_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "observation_date": {
+          "name": "observation_date",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "observation_reviewed": {
+          "name": "observation_reviewed",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "observation_valid": {
+          "name": "observation_valid",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "photo_count": {
+          "default": 0,
+          "name": "photo_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "presence_noted": {
+          "name": "presence_noted",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "species_code": {
+          "name": "species_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "sub_id": {
+          "name": "sub_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "video_count": {
+          "default": 0,
+          "name": "video_count",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observations_species_code_sub_id_pk": {
+          "columns": ["species_code", "sub_id"],
+          "name": "observations_species_code_sub_id_pk"
+        }
+      },
+      "foreignKeys": {
+        "observations_location_id_locations_id_fk": {
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "name": "observations_location_id_locations_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "observations",
+          "tableTo": "locations"
+        }
+      },
+      "indexes": {
+        "obs_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_created_at_idx",
+          "with": {}
+        },
+        "obs_location_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "location_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_location_date_idx",
+          "with": {}
+        },
+        "obs_review_valid_date_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "observation_reviewed",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_valid",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "observation_date",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "obs_review_valid_date_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "observations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_items": {
+      "checkConstraints": {},
+      "columns": {
+        "content_html": {
+          "name": "content_html",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "last_updated": {
+          "default": "CURRENT_TIMESTAMP",
+          "name": "last_updated",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "link": {
+          "name": "link",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "published_at": {
+          "name": "published_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "source_id": {
+          "name": "source_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "title": {
+          "name": "title",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "rss_items_source_id_rss_sources_id_fk": {
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "name": "rss_items_source_id_rss_sources_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "cascade",
+          "tableFrom": "rss_items",
+          "tableTo": "rss_sources"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_items",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.rss_sources": {
+      "checkConstraints": {},
+      "columns": {
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "rss_sources",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
 }

--- a/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,770 @@
+{
+  "id": "f8b3b934-4165-4200-be4c-3fe339cd6a6a",
+  "prevId": "17c6dfd7-1fbd-49dd-827e-0ae2bdfaa669",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.channel_ebird_subscriptions": {
+      "name": "channel_ebird_subscriptions",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county_code": {
+          "name": "county_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "state_county_idx": {
+          "name": "state_county_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "county_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_state_county_idx": {
+          "name": "active_state_county_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "county_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_ebird_subscriptions_channel_id_state_code_county_code_pk": {
+          "name": "channel_ebird_subscriptions_channel_id_state_code_county_code_pk",
+          "columns": [
+            "channel_id",
+            "state_code",
+            "county_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_rss_subscriptions": {
+      "name": "channel_rss_subscriptions",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_rss_subscriptions_id_rss_sources_id_fk": {
+          "name": "channel_rss_subscriptions_id_rss_sources_id_fk",
+          "tableFrom": "channel_rss_subscriptions",
+          "tableTo": "rss_sources",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_rss_subscriptions_channel_id_id_pk": {
+          "name": "channel_rss_subscriptions_channel_id_id_pk",
+          "columns": [
+            "channel_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.county_timezones": {
+      "name": "county_timezones",
+      "schema": "",
+      "columns": {
+        "county_code": {
+          "name": "county_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        }
+      },
+      "indexes": {
+        "county_code_idx": {
+          "name": "county_code_idx",
+          "columns": [
+            {
+              "expression": "county_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deliveries": {
+      "name": "deliveries",
+      "schema": "",
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alert_kind": {
+          "name": "alert_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deliveries_unique_idx": {
+          "name": "deliveries_unique_idx",
+          "columns": [
+            {
+              "expression": "alert_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deliveries_channel_idx": {
+          "name": "deliveries_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filtered_species": {
+      "name": "filtered_species",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "common_name_channel_id_idx": {
+          "name": "common_name_channel_id_idx",
+          "columns": [
+            {
+              "expression": "common_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "filtered_species_common_name_channel_id_pk": {
+          "name": "filtered_species_common_name_channel_id_pk",
+          "columns": [
+            "common_name",
+            "channel_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "county": {
+          "name": "county",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county_code": {
+          "name": "county_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "county_state_code_idx": {
+          "name": "county_state_code_idx",
+          "columns": [
+            {
+              "expression": "county_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observations": {
+      "name": "observations",
+      "schema": "",
+      "columns": {
+        "audio_count": {
+          "name": "audio_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "has_comments": {
+          "name": "has_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_many": {
+          "name": "how_many",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_date": {
+          "name": "observation_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_reviewed": {
+          "name": "observation_reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observation_valid": {
+          "name": "observation_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_count": {
+          "name": "photo_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "presence_noted": {
+          "name": "presence_noted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scientific_name": {
+          "name": "scientific_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species_code": {
+          "name": "species_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_id": {
+          "name": "sub_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_count": {
+          "name": "video_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "obs_created_at_idx": {
+          "name": "obs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "obs_location_date_idx": {
+          "name": "obs_location_date_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "obs_review_valid_date_idx": {
+          "name": "obs_review_valid_date_idx",
+          "columns": [
+            {
+              "expression": "observation_reviewed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_valid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observation_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observations_location_id_locations_id_fk": {
+          "name": "observations_location_id_locations_id_fk",
+          "tableFrom": "observations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "observations_species_code_sub_id_pk": {
+          "name": "observations_species_code_sub_id_pk",
+          "columns": [
+            "species_code",
+            "sub_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_items": {
+      "name": "rss_items",
+      "schema": "",
+      "columns": {
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_items_source_id_rss_sources_id_fk": {
+          "name": "rss_items_source_id_rss_sources_id_fk",
+          "tableFrom": "rss_items",
+          "tableTo": "rss_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_sources": {
+      "name": "rss_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/scrubjay-discord/src/drizzle/meta/_journal.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/_journal.json
@@ -23,11 +23,11 @@
       "when": 1763787622015
     },
     {
-      "breakpoints": true,
       "idx": 3,
-      "tag": "0003_brainy_zzzax",
       "version": "7",
-      "when": 1763866712369
+      "when": 1763867254460,
+      "tag": "0003_freezing_princess_powerful",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/apps/scrubjay-discord/src/drizzle/meta/_journal.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/_journal.json
@@ -21,6 +21,13 @@
       "tag": "0002_silky_psylocke",
       "version": "7",
       "when": 1763787622015
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1763866712369,
+      "tag": "0003_brainy_zzzax",
+      "breakpoints": true
     }
   ],
   "version": "7"

--- a/apps/scrubjay-discord/src/drizzle/meta/_journal.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/_journal.json
@@ -23,11 +23,11 @@
       "when": 1763787622015
     },
     {
+      "breakpoints": true,
       "idx": 3,
-      "version": "7",
-      "when": 1763866712369,
       "tag": "0003_brainy_zzzax",
-      "breakpoints": true
+      "version": "7",
+      "when": 1763866712369
     }
   ],
   "version": "7"

--- a/apps/scrubjay-discord/src/drizzle/meta/_journal.json
+++ b/apps/scrubjay-discord/src/drizzle/meta/_journal.json
@@ -23,11 +23,11 @@
       "when": 1763787622015
     },
     {
+      "breakpoints": true,
       "idx": 3,
-      "version": "7",
-      "when": 1763867254460,
       "tag": "0003_freezing_princess_powerful",
-      "breakpoints": true
+      "version": "7",
+      "when": 1763867254460
     }
   ],
   "version": "7"


### PR DESCRIPTION
Creates a composite primary key on channeId/sourceId

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Create composite primary key (channel_id, id) for `channel_rss_subscriptions` and enforce non-null `id` (sourceId), with schema and migration updates.
> 
> - **Database (scrubjay-discord)**
>   - **Schema**: Update `channel_rss_subscriptions` to use composite primary key `channel_id + id` and make `id` (sourceId) `NOT NULL` in `drizzle.schema.ts`.
>   - **Migration**: Add SQL migration `0003_freezing_princess_powerful.sql` to set `id` NOT NULL and add composite PK; update Drizzle meta snapshot and journal.
> - **Changeset**: Add patch changeset noting the bugfix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 940bc6c62c412c1faf075393b21a81d068e70389. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->