### PR TITLE
fix: set bot status to "looking for birds..."

### DIFF
--- a/.changeset/eight-chicken-jam.md
+++ b/.changeset/eight-chicken-jam.md
@@ -1,0 +1,5 @@
+---
+"scrubjay-discord": patch
+---
+
+update status text to read "looking for birds..."

--- a/apps/scrubjay-discord/src/discord/listeners/lifecycle-listener.service.ts
+++ b/apps/scrubjay-discord/src/discord/listeners/lifecycle-listener.service.ts
@@ -6,8 +6,8 @@ import { Context, ContextOf, On } from "necord";
 export class LifecycleListenerService {
   @On(Events.ClientReady)
   async onClientReady(@Context() [client]: ContextOf<Events.ClientReady>) {
-    client.user.setActivity("for birds", {
-      type: ActivityType.Listening,
+    client.user.setActivity("looking for birds...", {
+      type: ActivityType.Custom,
     });
   }
 }


### PR DESCRIPTION
Discord has apparently changed the way custom activity statuses are rendered. This updates to a custom status.