### PR TITLE
perf(scrubjay-discord): dispatch alert plans concurrently across channels

### DIFF
--- a/.changeset/parallel-channel-dispatch.md
+++ b/.changeset/parallel-channel-dispatch.md
@@ -1,0 +1,10 @@
+---
+"scrubjay-discord": patch
+---
+
+Dispatch alert plans concurrently across channels. Sends to different channels
+run in parallel (they are independent Discord rate-limit buckets) while sends
+within a channel stay sequential, preserving message order and the send-then-
+record crash-safety protocol. Cuts dispatch tick wall time from the sum of all
+sends to the slowest single channel's chain (~14s → ~1-2s on a typical
+multi-channel tick).

--- a/apps/scrubjay-discord/src/features/dispatch/alert-metrics.ts
+++ b/apps/scrubjay-discord/src/features/dispatch/alert-metrics.ts
@@ -3,7 +3,7 @@
  *  instruments only when name + description + unit all match, so both sites
  *  MUST build from this one constant. */
 export const ALERT_OUTCOMES_COUNTER = {
-  name: "scrubjay.dispatch.alerts",
   description: "Alert delivery outcomes by status",
+  name: "scrubjay.dispatch.alerts",
   unit: "{alert}",
 } as const;

--- a/apps/scrubjay-discord/src/features/dispatch/dispatch.service.spec.ts
+++ b/apps/scrubjay-discord/src/features/dispatch/dispatch.service.spec.ts
@@ -54,7 +54,10 @@ const metricHarness = registerMetricHarness();
 
 async function alertCount(status: string): Promise<number | undefined> {
   const metric = await metricHarness.collect("scrubjay.dispatch.alerts");
-  return metric?.dataPoints.find((p) => p.attributes.status === status)?.value;
+  const value = metric?.dataPoints.find(
+    (p) => p.attributes.status === status,
+  )?.value;
+  return typeof value === "number" ? value : undefined;
 }
 
 describe("DispatchService", () => {
@@ -131,8 +134,16 @@ describe("DispatchService", () => {
 
   it("counts expired alerts swept off the queue", async () => {
     alertQueueMock.sweepExpired.mockResolvedValue([
-      { alertId: "verfly:S9", channelId: "CH1", comName: "Vermilion Flycatcher" },
-      { alertId: "verfly:S10", channelId: "CH1", comName: "Vermilion Flycatcher" },
+      {
+        alertId: "verfly:S9",
+        channelId: "CH1",
+        comName: "Vermilion Flycatcher",
+      },
+      {
+        alertId: "verfly:S10",
+        channelId: "CH1",
+        comName: "Vermilion Flycatcher",
+      },
     ]);
 
     await service.dispatchSince(since);
@@ -207,20 +218,71 @@ describe("DispatchService", () => {
 
   it("records each plan immediately after its send (per-plan, not batched)", async () => {
     alertQueueMock.pendingEBirdAlerts.mockResolvedValue([
-      makeAlert({ channelId: "CH1" }),
-      makeAlert({ channelId: "CH2" }),
+      makeAlert({ speciesCode: "verfly" }),
+      makeAlert({ comName: "American Golden-Plover", speciesCode: "amgplo" }),
     ]);
     const calls: string[] = [];
-    senderMock.send.mockImplementation(async (channelId: string) => {
-      calls.push(`send:${channelId}`);
+    senderMock.send.mockImplementation(async () => {
+      calls.push("send");
     });
     alertQueueMock.record.mockImplementation(async (alerts: unknown[]) => {
-      calls.push(`record:${(alerts as { channelId: string }[])[0].channelId}`);
+      calls.push(
+        `record:${(alerts as { speciesCode: string }[])[0].speciesCode}`,
+      );
     });
 
     await service.dispatchSince(since);
 
-    expect(calls).toEqual(["send:CH1", "record:CH1", "send:CH2", "record:CH2"]);
+    expect(calls).toEqual(["send", "record:verfly", "send", "record:amgplo"]);
+  });
+
+  it("sends to different channels concurrently", async () => {
+    alertQueueMock.pendingEBirdAlerts.mockResolvedValue([
+      makeAlert({ channelId: "CH1" }),
+      makeAlert({ channelId: "CH2" }),
+    ]);
+    const events: string[] = [];
+    senderMock.send.mockImplementation(
+      (channelId: string) =>
+        new Promise<void>((resolve) => {
+          events.push(`start:${channelId}`);
+          setTimeout(
+            () => {
+              events.push(`end:${channelId}`);
+              resolve();
+            },
+            channelId === "CH1" ? 30 : 1,
+          );
+        }),
+    );
+
+    await service.dispatchSince(since);
+
+    expect(events).toEqual(["start:CH1", "start:CH2", "end:CH2", "end:CH1"]);
+  });
+
+  it("keeps sends within one channel sequential", async () => {
+    alertQueueMock.pendingEBirdAlerts.mockResolvedValue([
+      makeAlert({ speciesCode: "verfly" }),
+      makeAlert({ comName: "American Golden-Plover", speciesCode: "amgplo" }),
+    ]);
+    let inFlight = 0;
+    const observedInFlight: number[] = [];
+    senderMock.send.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          inFlight += 1;
+          observedInFlight.push(inFlight);
+          setTimeout(() => {
+            inFlight -= 1;
+            resolve();
+          }, 5);
+        }),
+    );
+
+    await service.dispatchSince(since);
+
+    expect(observedInFlight).toEqual([1, 1]);
   });
 
   it("records a permanent permission failure as failed without deactivating", async () => {

--- a/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
+++ b/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
@@ -68,8 +68,6 @@ export class DispatchService {
           const refs = plan.alerts.map(toAlertRef);
           try {
             await this.sender.send(plan.channelId, plan.message);
-            // Record immediately: a crash now loses at most this one plan's
-            // records instead of the whole tick's (at-least-once, spec §2).
             await this.alertQueue.record(refs, "sent");
             this.alerts.add(refs.length, { status: "sent" });
             sentCount += refs.length;

--- a/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
+++ b/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { metrics } from "@opentelemetry/api";
 import { MessageSenderService } from "@/discord/message-sender.service";
+import { ALERT_OUTCOMES_COUNTER } from "./alert-metrics";
 import {
   AlertQueue,
   type AlertRef,
   type PendingEBirdAlert,
 } from "./alert-queue.service";
-import { ALERT_OUTCOMES_COUNTER } from "./alert-metrics";
 import { classifySendError } from "./discord-error";
-import { planEBirdAlerts } from "./ebird-alert.formatter";
+import { type DispatchPlan, planEBirdAlerts } from "./ebird-alert.formatter";
 
 /** Sweep scan floor — matches the eBird fetch lookback (back=7). */
 const SWEEP_FLOOR_MS = 7 * 24 * 60 * 60 * 1000;
@@ -50,20 +50,37 @@ export class DispatchService {
       this.logger.debug(`No new alerts since ${since.toISOString()}`);
     }
 
-    let sentCount = 0;
+    // Channels are independent Discord rate-limit buckets, so they dispatch
+    // concurrently; within a channel, plans stay sequential to preserve
+    // message order and the per-channel rate limit.
+    const plansByChannel = new Map<string, DispatchPlan[]>();
     for (const plan of planEBirdAlerts(pending)) {
-      const refs = plan.alerts.map(toAlertRef);
-      try {
-        await this.sender.send(plan.channelId, plan.message);
-        // Record immediately: a crash now loses at most this one plan's
-        // records instead of the whole tick's (at-least-once, spec §2).
-        await this.alertQueue.record(refs, "sent");
-        this.alerts.add(refs.length, { status: "sent" });
-        sentCount += refs.length;
-      } catch (err) {
-        await this.handleSendFailure(plan.channelId, refs, err);
+      const channelPlans = plansByChannel.get(plan.channelId);
+      if (channelPlans) {
+        channelPlans.push(plan);
+      } else {
+        plansByChannel.set(plan.channelId, [plan]);
       }
     }
+
+    let sentCount = 0;
+    await Promise.all(
+      Array.from(plansByChannel.values(), async (plans) => {
+        for (const plan of plans) {
+          const refs = plan.alerts.map(toAlertRef);
+          try {
+            await this.sender.send(plan.channelId, plan.message);
+            // Record immediately: a crash now loses at most this one plan's
+            // records instead of the whole tick's (at-least-once, spec §2).
+            await this.alertQueue.record(refs, "sent");
+            this.alerts.add(refs.length, { status: "sent" });
+            sentCount += refs.length;
+          } catch (err) {
+            await this.handleSendFailure(plan.channelId, refs, err);
+          }
+        }
+      }),
+    );
 
     if (sentCount > 0) {
       this.logger.log(`Delivered ${sentCount} alerts`);

--- a/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
+++ b/apps/scrubjay-discord/src/features/dispatch/dispatch.service.ts
@@ -50,9 +50,7 @@ export class DispatchService {
       this.logger.debug(`No new alerts since ${since.toISOString()}`);
     }
 
-    // Channels are independent Discord rate-limit buckets, so they dispatch
-    // concurrently; within a channel, plans stay sequential to preserve
-    // message order and the per-channel rate limit.
+    // Channels are independent rate-limit buckets: concurrent across, sequential within.
     const plansByChannel = new Map<string, DispatchPlan[]>();
     for (const plan of planEBirdAlerts(pending)) {
       const channelPlans = plansByChannel.get(plan.channelId);

--- a/apps/scrubjay-discord/src/features/jobs/bootstrap.service.spec.ts
+++ b/apps/scrubjay-discord/src/features/jobs/bootstrap.service.spec.ts
@@ -1,5 +1,13 @@
 import { Logger } from "@nestjs/common";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { AlertQueue } from "@/features/dispatch/alert-queue.service";
 import type { IngestService } from "@/features/ingest/ingest.service";
 import type { SourcesRepository } from "@/features/sources/sources.repository";


### PR DESCRIPTION
## Why

Dispatch has a 1s p95 SLO but ticks were taking ~15s. Trace `d9359e3e3c9df16a8e498ad774f14d8c` shows the whole 14s is 26 strictly-sequential `INSERT delivery → POST to Discord` iterations (each POST 200–900ms) across only 8 channels — pure serialization of network round-trips, no individually slow operation.

## What

- Group dispatch plans by channel and run channels concurrently under `Promise.all`. Channels are independent Discord rate-limit buckets, so this is safe with discord.js's per-route rate limiter.
- Sends **within** a channel stay sequential, preserving message order and per-channel rate-limit behavior.
- The send-then-record protocol is untouched and still per-plan, so at-least-once delivery semantics are unchanged; a failure in one channel's chain can't affect the others (per-plan try/catch, as before).
- New tests: cross-channel sends overlap; within-channel sends never overlap. The per-plan record-ordering test was reworked to two same-channel plans since cross-channel global ordering is no longer deterministic (the crash-safety intent it pins is unchanged).

Also includes a chore commit fixing the pre-existing `check-types` and `biome check` failures on main (CI is `pull_request`-only, so recent direct pushes never ran it): the metric-harness `alertCount` helper now narrows to numeric data points, plus biome safe fixes.

## Expected impact

Tick wall time drops from the sum of all sends to the slowest single channel's chain — for the traced tick, roughly 14s → 2–5s (the two channels with 9 messages each become the new critical path; the per-channel ~5 msgs/5s Discord limit is the remaining floor). Getting to a true 1s p95 on high fan-out ticks would additionally require batching embeds per message, which conflicts with the per-message 👎 filter-reaction UX — deliberately out of scope here.

## Verification

- `pnpm run test` — 42 files, 243 tests pass
- `pnpm run check-types` — clean (was failing on main)
- `pnpm run format-and-lint` — clean (was failing on main)